### PR TITLE
[Changed] Rename FugleMetaLoader to FugleHttpLoader

### DIFF
--- a/Examples/Realtime Demo/Realtime Demo/ContentView.swift
+++ b/Examples/Realtime Demo/Realtime Demo/ContentView.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
     var body: some View {
         Button("Hello, world!") {
             Task {
-                let result = await FugleMetaLoader().load(token: "", symbolId: "2330")
+                let result = await FugleHttpLoader().loadMeta(token: "", symbolId: "2330")
                 let model = try? result.get()
                 if let model {
                     print(model)

--- a/Sources/fugle-realtime-swift/FugleHttpLoader.swift
+++ b/Sources/fugle-realtime-swift/FugleHttpLoader.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public class FugleMetaLoader {
-
+public class FugleHttpLoader {
+    
     public init() {}
-
-    public func load(token: String, symbolId: String) async -> Result<Intraday<MetaData>, Error> {
+    
+    public func loadMeta(token: String, symbolId: String) async -> Result<Intraday<MetaData>, Error> {
         let parameters = ["symbolId": symbolId, "apiToken": token]
         let url = IntradayRouter.meta(parameters: parameters).url
-
+        
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
             let meta = try JSONDecoder().decode(Intraday<MetaData>.self, from: data)


### PR DESCRIPTION
## Description

Loader 裡要新增其他的 api，所以先將 `FugleMetaLoader`  改為 `FugleHttpLoader `

## Architecture

``` dart
public class FugleHttpLoader {
  public func loadMeta(token: String, symbolId: String) {}
  // public func loadQuote(token: String, symbolId: String) {}
  // public func loadChart(token: String, symbolId: String) {}
  // ..
}
```