### PR TITLE
[Added] 新增 WebSocket 支援

### DIFF
--- a/Sources/fugle-realtime-swift/Models/Info.swift
+++ b/Sources/fugle-realtime-swift/Models/Info.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct Info: Codable {
-    let date: String
-    let type: String
-    let exchange: String
-    let market: String
-    let symbolId: String
-    let countryCode: String
-    let timeZone: String
-    let lastUpdatedAt: String?
+public struct Info: Codable {
+    public let date: String
+    public let type: String
+    public let exchange: String
+    public let market: String
+    public let symbolId: String
+    public let countryCode: String
+    public let timeZone: String
+    public let lastUpdatedAt: String?
 }

--- a/Sources/fugle-realtime-swift/Models/Intraday.swift
+++ b/Sources/fugle-realtime-swift/Models/Intraday.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public struct Intraday<T: Codable>: Codable {
-    let apiVersion: String
-    let data: T
+    public let apiVersion: String
+    public let data: T
 }
 
 public struct MetaData: Codable {
-    let info: Info
-    let meta: Meta
+    public let info: Info
+    public let meta: Meta
 }
 
 public struct ChartData: Codable {

--- a/Sources/fugle-realtime-swift/Models/Meta.swift
+++ b/Sources/fugle-realtime-swift/Models/Meta.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-struct Meta: Codable {
-    let market: String
-    let nameZhTw: String
-    let industryZhTw: String
-    let priceReference: Double
-    let priceHighLimit: Double
-    let priceLowLimit: Double
-    let canDayBuySell: Bool
-    let canDaySellBuy: Bool
-    let canShortMargin: Bool
-    let canShortLend: Bool
-    let tradingUnit: Int
-    let currency: String
-    let isTerminated: Bool
-    let isSuspended: Bool
-    let typeZhTw: String
-    let abnormal: String
-    let isUnusuallyRecommended: Bool
+public struct Meta: Codable {
+    public let market: String
+    public let nameZhTw: String
+    public let industryZhTw: String?
+    public let priceReference: Double
+    public let priceHighLimit: Double
+    public let priceLowLimit: Double
+    public let canDayBuySell: Bool
+    public let canDaySellBuy: Bool
+    public let canShortMargin: Bool?
+    public let canShortLend: Bool?
+    public let tradingUnit: Int
+    public let currency: String?
+    public let isTerminated: Bool
+    public let isSuspended: Bool
+    public let typeZhTw: String
+    public let abnormal: String
+    public let isUnusuallyRecommended: Bool?
 }

--- a/Sources/fugle-realtime-swift/URLSessionWebSocketTask+Extension.swift
+++ b/Sources/fugle-realtime-swift/URLSessionWebSocketTask+Extension.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum WebSocketError: Error {
+    case invalidFormat
+}
+
+extension URLSessionWebSocketTask.Message {
+    public func meta() throws -> Intraday<MetaData> {
+        switch self {
+        case .string(let json):
+            guard let data = json.data(using: .utf8) else {
+                throw WebSocketError.invalidFormat
+            }
+
+            return try JSONDecoder().decode(Intraday<MetaData>.self, from: data)
+
+        case .data:
+            throw WebSocketError.invalidFormat
+
+        @unknown default:
+            throw WebSocketError.invalidFormat
+        }
+    }
+}
+
+// TODO: 新增 chart, quote 的資料解析

--- a/Sources/fugle-realtime-swift/WebSocketRouter.swift
+++ b/Sources/fugle-realtime-swift/WebSocketRouter.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// API Document: https://developer.fugle.tw/docs/data/intraday/overview
+
+public enum WebSocketRouter {
+    public typealias Parameters = [String: String]
+
+    case meta(parameters: Parameters)
+    // TODO: add new cases
+    // case chart(parameters: Parameters)
+    // case quote(parameters: Parameters)
+}
+
+extension WebSocketRouter: APIRouter {
+    public var scheme: String { "wss" }
+
+    public var parameters: [String : String]? {
+        switch self {
+        case let .meta(parameters):
+            return parameters
+        }
+    }
+
+    public var path: String {
+        switch self {
+        case .meta:
+            return "/meta"
+        }
+    }
+}

--- a/Sources/fugle-realtime-swift/WebSocketStream.swift
+++ b/Sources/fugle-realtime-swift/WebSocketStream.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public class WebSocketStream {
+    public typealias Element = URLSessionWebSocketTask.Message
+    public typealias AsyncIterator = AsyncThrowingStream<URLSessionWebSocketTask.Message, Error>.Iterator
+
+    private var stream: AsyncThrowingStream<Element, Error>?
+    private var continuation: AsyncThrowingStream<Element, Error>.Continuation?
+    private let socket: URLSessionWebSocketTask
+
+    public init(url: URL, session: URLSession = URLSession.shared) {
+        socket = session.webSocketTask(with: url)
+        stream = AsyncThrowingStream { continuation in
+            self.continuation = continuation
+            self.continuation?.onTermination = { @Sendable [socket] _ in
+                socket.cancel()
+            }
+        }
+    }
+}
+
+extension WebSocketStream: AsyncSequence {
+    public func makeAsyncIterator() -> AsyncIterator {
+        guard let stream = stream else {
+            fatalError("stream was not initialized")
+        }
+        socket.resume()
+        listenForMessages()
+        return stream.makeAsyncIterator()
+    }
+
+    private func listenForMessages() {
+        socket.receive { [unowned self] result in
+            switch result {
+            case .success(let message):
+                continuation?.yield(message)
+                listenForMessages()
+            case .failure(let error):
+                continuation?.finish(throwing: error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
新增 WebSocket 支援

1. 用 `AsyncStream` 來實作，[參考範例](https://obscuredpixels.com/awaiting-websockets-in-swiftui)。
2. 取得 `Meat` 的 Scoket 資料，並實作於 Demo App，如下圖，顯示股名與參考價：

![Simulator Screen Shot - iPhone 13 mini - 2022-12-06 at 23 10 59](https://user-images.githubusercontent.com/21169170/205950380-576383ab-88b5-4e69-8876-988b4a564ff0.png)

## TODO
取得 Chart & Quote 的資料。

