### PR TITLE
[Doc] add pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+* [Feature](?expand=1&template=feature.md)
+* [Issue](?expand=1&template=issue.md)


### PR DESCRIPTION
因為上發商一個 PR 時，發現不好使用之前加的 template，因為我們的 template 是複數的，放在一個資料夾內，之前是參考這篇的做法：https://stackoverflow.com/a/73870512/7102802

但要自己手動在網址加上 query string。

所以這個 pr 依照 stackoverflow [下一則 comment 提到的](https://stackoverflow.com/a/75030350/7102802)，多一個檔案，讓發 pr 的人知道有哪些 templates 可用，並有相關的 query string 方便複製貼上。