### PR TITLE
[Fixed] 修正 Chart View X 軸資料顯示

### DIFF
--- a/Examples/Realtime Demo/Realtime Demo/Extensions/Foundation+Extensions.swift
+++ b/Examples/Realtime Demo/Realtime Demo/Extensions/Foundation+Extensions.swift
@@ -5,3 +5,16 @@ extension Double {
         String(format: "%.2f", self)
     }
 }
+
+extension Date {
+
+    func dateComponents(timeZone: TimeZone, calendar: Calendar = .current) -> DateComponents {
+        let current = calendar.dateComponents(in: timeZone, from: self)
+
+        var dc = DateComponents(timeZone: timeZone, year: current.year, month: current.month)
+        dc.hour = current.hour
+
+        return dc
+    }
+
+}


### PR DESCRIPTION
## Description

原先的 Chart View 無法正常顯示 X 軸資料顯示，此 PR 修正之。

## Architecture

<img width="401" alt="Screenshot 2023-04-18 at 9 04 41 PM" src="https://user-images.githubusercontent.com/21169170/232786442-ea7d1535-8f24-4035-8ec9-da003f980cfd.png">

關於呈現不同時間區間的資料來源，Fugle realtime api - [candle](https://developer.fugle.tw/docs/data/marketdata/candles)，給的資料看起來還是用天為單位，沒有周、月、年的樣子。

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
